### PR TITLE
Minor code cleanup

### DIFF
--- a/utils/binary_metrics.py
+++ b/utils/binary_metrics.py
@@ -61,7 +61,7 @@ class Metrics():
         self._pred_labels = []
         self._labels = []
 
-    def update(self, scores = None, pred_labels = None, labels = None, adjust=False):
+    def update(self, scores = None, pred_labels = None, labels = None):
         if scores is not None:
             self._scores.append(scores)
         if pred_labels is not None:
@@ -75,7 +75,6 @@ class Metrics():
             scores = torch.cat(self._scores) if self._scores else None,
             pred_labels = torch.cat(self._pred_labels) if self._pred_labels else None,
             labels = torch.cat(self._labels) if self._labels else None,
-            adjust=False,
             avoid_curves=self.avoid_curves,
             avoid_thresholds=self.avoid_thresholds
         )        
@@ -91,6 +90,6 @@ if __name__ == "__main__":
 
     
     metrics = Metrics(avoid_curves=True)
-    metrics.update(scores, pred_labels, labels, adjust=False)
+    metrics.update(scores, pred_labels, labels)
     average_results = metrics.compute()
     print(average_results)


### PR DESCRIPTION
This pull request introduces a minor change to `binary_metrics.py` by removing the unused `adjust` parameter from the `update` method of the `Metrics` class (and its related calls).

This also fixes the following error when you directly run the `binary_metrics.py` script as the main program:

```
python utils/binary_metrics.py

Traceback (most recent call last):
  File "/home/matteo/PycharmProjects/PytorchTemplateFork/utils/binary_metrics.py", line 95, in <module>
    average_results = metrics.compute()
                      ^^^^^^^^^^^^^^^^^
  File "/home/matteo/PycharmProjects/PytorchTemplateFork/utils/binary_metrics.py", line 74, in compute
    result.measure(
TypeError: MetricResults.measure() got an unexpected keyword argument 'adjust'
```

> [!NOTE]
> This is my second PR attempt. I'm still learning the ropes, so I've put up this small PR mainly to practice the contribution process. The change itself is minor and a PR is not really needed here, but I wanted to start with something simple.
